### PR TITLE
Reuse for CI in deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   build:
@@ -19,6 +22,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,8 @@ jobs:
         node-version: [16.17.0]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+      - name: CI build
+        uses: ./.github/workflows/ci.yml
 
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -51,23 +45,6 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
-
-      - name: Restore cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
-
-      - name: Install dependencies
-        run: yarn
-
-      - name: Build with Next.js
-        run: yarn build
 
       - name: Set CNAME file for proper static asset loading
         run: echo 'blog.maffin.io' > ./out/CNAME


### PR DESCRIPTION
Before this we had CI and deploy running concurrently for master which is useless. Tests may fail and still deploy. This change reuses ci.yml workflow in the deploy pipeline making sure that if build fails, we won't deploy master.

<img width="1280" alt="Screenshot 2023-04-27 at 11 43 15" src="https://user-images.githubusercontent.com/3578154/234761376-2d34cb7d-088e-4f3e-b1ff-28330d3562d2.png">

